### PR TITLE
Change Frame.texture_coordinates() to return [f32; 2]

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -30,6 +30,7 @@ pub use std::{
     os::raw::{c_int, c_uchar, c_uint, c_void},
     path::Path,
     ptr::NonNull,
+    slice,
     sync::atomic::{AtomicPtr, Ordering},
     time::Duration,
 };

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -759,7 +759,7 @@ impl Frame<marker::Pose> {
 /// UV texture coordinates.
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct texture_coordinate {
+pub struct TextureCoordinate {
     pub u: f32,
     pub v: f32,
 }
@@ -770,8 +770,7 @@ impl Frame<marker::Points> {
         let n_points = self.points_count()?;
         unsafe {
             let mut checker = ErrorChecker::new();
-            let ptr =
-                realsense_sys::rs2_get_frame_vertices(self.ptr.as_ptr(), checker.inner_mut_ptr());
+            let ptr = realsense_sys::rs2_get_frame_vertices(self.ptr.as_ptr(), checker.inner_mut_ptr());
             checker.check()?;
             let slice = std::slice::from_raw_parts::<realsense_sys::rs2_vertex>(ptr, n_points);
             Ok(slice)
@@ -779,16 +778,16 @@ impl Frame<marker::Points> {
     }
 
     /// Gets texture coordinates of each point of point cloud.
-    pub fn texture_coordinates<'a>(&'a self) -> RsResult<&'a [texture_coordinate]> {
+    pub fn texture_coordinates<'a>(&'a self) -> RsResult<&'a [TextureCoordinate]> {
         unsafe {
             let n_points = self.points_count()?;
             let mut checker = ErrorChecker::new();
             let ptr = realsense_sys::rs2_get_frame_texture_coordinates(
                 self.ptr.as_ptr(),
                 checker.inner_mut_ptr(),
-            ) as *const texture_coordinate;
+            ) as *const TextureCoordinate;
             checker.check()?;
-            let slice = std::slice::from_raw_parts::<texture_coordinate>(ptr, n_points);
+            let slice = std::slice::from_raw_parts::<TextureCoordinate>(ptr, n_points);
             Ok(slice)
         }
     }

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -774,7 +774,8 @@ impl Frame<marker::Points> {
         let n_points = self.points_count()?;
         unsafe {
             let mut checker = ErrorChecker::new();
-            let ptr = realsense_sys::rs2_get_frame_vertices(self.ptr.as_ptr(), checker.inner_mut_ptr());
+            let ptr =
+                realsense_sys::rs2_get_frame_vertices(self.ptr.as_ptr(), checker.inner_mut_ptr());
             checker.check()?;
             let slice = std::slice::from_raw_parts::<realsense_sys::rs2_vertex>(ptr, n_points);
             Ok(slice)
@@ -797,9 +798,13 @@ impl Frame<marker::Points> {
             // rs2_get_frame_texture_coordinates() into a texture_coordinate*, thereby
             // re-interpreting [[c_int; 2]; N] as [[c_float; 2]; N] values.
             // Note that C does not generally guarantee that sizeof(int) == sizeof(float).
-            let slice = std::slice::from_raw_parts::<realsense_sys::rs2_pixel>(ptr, n_points);
-            let bytes = std::slice::from_raw_parts::<u8>(slice.as_ptr() as *const u8, std::mem::size_of_val(slice));
-            let tcs = safe_transmute::transmute_many::<TextureCoordinate, PedanticGuard>(bytes).unwrap();
+            let slice = slice::from_raw_parts::<realsense_sys::rs2_pixel>(ptr, n_points);
+            let bytes = slice::from_raw_parts::<u8>(
+                slice.as_ptr() as *const u8,
+                std::mem::size_of_val(slice),
+            );
+            let tcs =
+                safe_transmute::transmute_many::<TextureCoordinate, PedanticGuard>(bytes).unwrap();
             debug_assert_eq!(tcs.len(), n_points);
             Ok(tcs)
         }

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -756,6 +756,14 @@ impl Frame<marker::Pose> {
     }
 }
 
+/// UV texture coordinates.
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct texture_coordinate {
+    pub u: f32,
+    pub v: f32,
+}
+
 impl Frame<marker::Points> {
     /// Gets vertices of point cloud.
     pub fn vertices<'a>(&'a self) -> RsResult<&'a [realsense_sys::rs2_vertex]> {
@@ -771,16 +779,16 @@ impl Frame<marker::Points> {
     }
 
     /// Gets texture coordinates of each point of point cloud.
-    pub fn texture_coordinates<'a>(&'a self) -> RsResult<&'a [realsense_sys::rs2_pixel]> {
+    pub fn texture_coordinates<'a>(&'a self) -> RsResult<&'a [texture_coordinate]> {
         unsafe {
             let n_points = self.points_count()?;
             let mut checker = ErrorChecker::new();
             let ptr = realsense_sys::rs2_get_frame_texture_coordinates(
                 self.ptr.as_ptr(),
                 checker.inner_mut_ptr(),
-            );
+            ) as *const texture_coordinate;
             checker.check()?;
-            let slice = std::slice::from_raw_parts::<realsense_sys::rs2_pixel>(ptr, n_points);
+            let slice = std::slice::from_raw_parts::<texture_coordinate>(ptr, n_points);
             Ok(slice)
         }
     }


### PR DESCRIPTION
This pull request is related to issue #14 and changes the `texture_coordinates()` method of the `Frame` struct; it now returns instances of type `texture_coordinate` instead of `rs2_point` values.

In the `librealsense` C API, `rs2_get_frame_texture_coordinates` is defined [here](https://github.com/IntelRealSense/librealsense/blob/0adceb9dc6fce63c348346e1aef1b63c052a1db9/include/librealsense2/h/rs_frame.h#L217-L224) as

```c
rs2_pixel* rs2_get_frame_texture_coordinates(const rs2_frame* frame, rs2_error** error);
```

with `rs2_pixel` being defined [here](https://github.com/IntelRealSense/librealsense/blob/0adceb9dc6fce63c348346e1aef1b63c052a1db9/include/librealsense2/h/rs_types.h#L116-L120) as

```c
typedef struct rs2_pixel
{
    int ij[2];
} rs2_pixel;
```

that is, as a struct containing an `[i32; 2]`; bindgen is correctly creating a wrapper for that. However, the C++ API defines `get_texture_coordinates()` [here](https://github.com/IntelRealSense/librealsense/blob/0adceb9dc6fce63c348346e1aef1b63c052a1db9/include/librealsense2/hpp/rs_frame.hpp#L765-L775) as

```cpp
const texture_coordinate* get_texture_coordinates() const
{
    rs2_error* e = nullptr;
    auto res = rs2_get_frame_texture_coordinates(get(), &e);
    error::handle(e);
    return (const texture_coordinate*)res;
}
```

where `texture_coordinate` is

```cpp
struct texture_cstruct texture_coordinate {
    float u, v;
    operator const float*() const { return &u; }
};
```

In other words, the underlying texture coordinates are actually `f32` instead of `i32` and callers of the Rust method would need to transmute the coordinates first to make sense of them.

I added this functionality to the Rust API by introducing the type

```rust
#[repr(C)]
#[derive(Debug, Copy, Clone)]
pub struct texture_coordinate {
    pub u: f32,
    pub v: f32,
}
```

and returning that instead. The examples are updated accordingly and now render colored point clouds.