### PR TITLE
Simplify build script and use all paths and libraries from `pkg-config`

### DIFF
--- a/realsense-sys/Cargo.toml
+++ b/realsense-sys/Cargo.toml
@@ -14,9 +14,7 @@ repository = "https://github.com/jerry73204/realsense-rust"
 
 [build-dependencies]
 bindgen = { version = "0.54", optional = true }
-anyhow = "1.0"
 cc = { version = "1.0", features = ["parallel"] }
-lazy_static = "1.4"
 
 [target.'cfg(not(target_env = "msvc"))'.build-dependencies]
 pkg-config = { version = "0.3"  }

--- a/realsense-sys/src/lib.rs
+++ b/realsense-sys/src/lib.rs
@@ -1,4 +1,4 @@
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
-include!(concat!(env!("CARGO_MANIFEST_DIR"), "/bindings/bindings.rs"));
+include!("../bindings/bindings.rs");


### PR DESCRIPTION
First of all, thank you for this library, it's very useful :) We've been using it on a Raspberry PI, and so far we had no real issues.

However, I'd like to cross compile for the RPi, so I can work on my more beefy laptop with rust-analyzer blazing away :) For that, it would be nice if we can bypass `pkg-config` so we easily use the library from the RPi.

This PR makes the build script look at environment variables `LIBREALSENSE`, `LIBREALSENSE_INCLUDE_PATH` and optionally `LIBREALSENSE_LIBRARY_SEARCH_PATH`. If `LIBREALSENSE` is set, pkg-config is not invoked. By overriding the library and include path, I was able to cross-compile for `aarch64-linux-unknown-gnu`.

The first commit tries to simplify the build script and removes some external dependencies. It also avoids making assumptions about the information given by `pkg-config` in some places. It might be easiest to review the commits separately.

